### PR TITLE
fix: support `workflow_run` events for github status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+### Added
 - Added support for Gandi DNS provider
+
+### Fixed
+- Support `workflow_run` events for correct GitHub commit status (e.g., secure fork PR workflows)
 
 ## [0.1.0] - 2025-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.0.0] - 2025-08-25
+
 ### Added
 - Added support for Gandi DNS provider
 

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ jobs:
           cf_auth_token: ${{ secrets.CF_AUTH_TOKEN }}
 ```
 
-### Dual Workflows (With Fork PRs)
+### Dual Workflows (For Secure Fork PRs)
 
-For secure handling of fork PRs, use two separate workflows that pass artifacts between them:
+For secure deployments of PRs from forks, use two separate workflows that pass artifacts between them:
 
 **`.github/workflows/build.yml`** - Builds without secrets access:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/action.yml
+++ b/action.yml
@@ -162,10 +162,18 @@ runs:
         script: |
           const cid = '${{ inputs.cid }}';
 
-          // For PR events, we need to use the head SHA
-          const sha = context.eventName === 'pull_request'
-            ? context.payload.pull_request.head.sha
-            : context.sha;
+          // Determine the correct SHA based on the event type
+          let sha;
+          if (context.eventName === 'workflow_run') {
+            // For workflow_run events triggered by PRs, use the PR's head SHA
+            sha = context.payload.workflow_run.head_sha;
+          } else if (context.eventName === 'pull_request' || context.eventName === 'pull_request_target') {
+            // For PR events, use the head SHA
+            sha = context.payload.pull_request.head.sha;
+          } else {
+            // For push events, use the commit SHA
+            sha = context.sha;
+          }
 
           await github.rest.repos.createCommitStatus({
             owner: context.repo.owner,


### PR DESCRIPTION
ensures commit statuses are posted to the correct sha when the action is triggered from a `workflow_run` context (e.g., in fork pr workflows)

unlikely people will need this (usually this only runs on main branches), but for consistency we want to support the same behavior as in https://github.com/ipshipyard/ipfs-deploy-action/pull/37